### PR TITLE
ignore PNG existing quality when converting format

### DIFF
--- a/src/mod_dims_ops.c
+++ b/src/mod_dims_ops.c
@@ -278,7 +278,11 @@ dims_quality_operation (dims_request_rec *d, char *args, char **err) {
     int quality = apr_strtoi64(args, NULL, 0);
     int existing_quality = MagickGetImageCompressionQuality(d->wand);
 
-    if(quality < existing_quality) {
+    // if existing quality is 0, this means undefined, probably because the source was a lossless
+    // format (e.g. PNG)
+    // Not sure about the logic of never using a high quality than the source - what if we're doing
+    // a massive downsample? Leave as is for now though...
+    if(existing_quality == 0 || quality < existing_quality) {
         MAGICK_CHECK(MagickSetImageCompressionQuality(d->wand, quality), d);
     }
     return DIMS_SUCCESS;


### PR DESCRIPTION
Fixes problems where PNGs can't be converted to JPGs at anything other than default quality (92).

To test:

http://apache.statsdash.bn.gntech.systems:8090/2017/articles/2017-12-06-10-40/Humble_monthly_december.png/EG11/format/jpg/quality/75/Humble_monthly_december.jpg

That's it really :)